### PR TITLE
Add keyboard integration to move the player ship up and down

### DIFF
--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://f2mvg56vdijn"]
+[gd_scene load_steps=4 format=3 uid="uid://f2mvg56vdijn"]
 
+[ext_resource type="Script" path="res://scripts/player.gd" id="1_lbkd2"]
 [ext_resource type="Texture2D" uid="uid://bwk0ry4x1j7pw" path="res://assets/player_ship.png" id="1_rh0x2"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_c7fjf"]
@@ -8,6 +9,7 @@
 position = Vector2(54, 360)
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="."]
+script = ExtResource("1_lbkd2")
 
 [node name="ShipSprite" type="Sprite2D" parent="CharacterBody2D"]
 texture = ExtResource("1_rh0x2")

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,11 +1,29 @@
-extends Node
+extends CharacterBody2D  # Or KinematicBody2D if using Godot 3.x
+
+# Movement variables
+var speed = 300  # Movement speed in pixels per second
+var screen_bounds = Vector2(0, 0)  # Bounds to keep the player within the screen
+
+func _ready():
+	# Set bounds based on the viewport size
+	screen_bounds = Vector2(0, 300)
+	
+
+func handle_input(delta):
+	var velocity = Vector2.ZERO  # Start with zero movement
+
+	# Input handling for vertical movement
+	if Input.is_action_pressed("ui_up"):  # Move up
+		velocity.y -= speed
+	if Input.is_action_pressed("ui_down"):  # Move down
+		velocity.y += speed
+
+	# Apply movement based on delta time
+	position += velocity * delta
+
+	# Constrain the position to stay within vertical bounds
+	position.y = clamp(position.y, -300, screen_bounds.y)
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
-	pass
+func _process(delta):
+	handle_input(delta)


### PR DESCRIPTION
- Add up and down keyboard inputs listeners to move the player ship vertically inside screen bounds.